### PR TITLE
Refer to qemu-system-riscv32

### DIFF
--- a/qemu/esp32c3/README.md
+++ b/qemu/esp32c3/README.md
@@ -33,7 +33,7 @@ After configuring the project successfully, `ninja` can be used to build it:
 ninja -C build
 ```
 
-Compilation can take a few minutes depending on the components that were enabled or disabled previously. Upon completion, `build/qemu-system-xtensa` should be created.
+Compilation can take a few minutes depending on the components that were enabled or disabled previously. Upon completion, `build/qemu-system-riscv32` should be created.
 
 # Compiling the ESP-IDF program to emulate
 


### PR DESCRIPTION
It is probably a leftover from the documentation overhaul