### PR TITLE
doc: qemu: add riscv32-softmmu to the build example

### DIFF
--- a/qemu/esp32/README.md
+++ b/qemu/esp32/README.md
@@ -15,7 +15,7 @@ In addition to QEMU's prerequisites, make sure that `libgcrypt` is installed on 
 To generate the `ninja` build files, we need to configure the project first, the following command can be used for that:
 
 ```bash
-./configure --target-list=xtensa-softmmu \
+./configure --target-list='xtensa-softmmu riscv32-softmmu' \
     --enable-gcrypt \
     --enable-slirp \
     --enable-debug --enable-sanitizers \


### PR DESCRIPTION
The build example is the same for riscv32-softmmu.  Add riscv32-softmmu to the --target-list.

See also: https://github.com/espressif/esp-idf/pull/12863