### PR TITLE
qemu: Update documentation related to running esptool.py and espefuse.py

### DIFF
--- a/qemu/esp32/README.md
+++ b/qemu/esp32/README.md
@@ -45,7 +45,7 @@ QEMU for ESP32 target is ready, it already includes the first stage bootloader, 
 
 Thus, in this section, we are going to create a flash image that combines the (second stage) bootloader, the partition table and the application to run. This can be done using `esptool.py merge_bin` command, supported in `esptool.py` 3.1 or later. Let's suppose that the ESP-IDf project has just been compiled successfully, the following commands will create that flash image:
 
-```bash
+```
 cd build
 esptool.py --chip esp32 merge_bin --fill-flash-size 4MB -o flash_image.bin @flash_args
 ```
@@ -167,10 +167,12 @@ Add extra arguments to the command line:
 
 The first argument creates a block device backed by `qemu_efuse.bin` file, with identifier `efuse`. The second line configures `nvram.esp32.efuse` device to use this block device for storage.
 
-The file must be created before starting QEMU:
+The `qemu_efuse.bin` file must be created before starting QEMU.
+You can keep this file any directory you wish, but we recommend to keep it in the same directory as `flash_image.bin` we created above to follow along with this tutorial. 
 
 ```
-dd if=/dev/zero bs=1 count=124 of=/tmp/qemu_efuse.bin
+cd build 
+dd if=/dev/zero bs=1 count=124 of=qemu_efuse.bin
 ```
 
 124 bytes is the total size of ESP32 eFuse blocks.
@@ -201,8 +203,8 @@ To convert this (`efuse.hex`) back to binary, run `xxd -r -p efuse.hex qemu_efus
 Alternatively, these bits can be set using espefuse:
 
 ```
-espefuse.py --port=socket://localhost:5555 burn_efuse CHIP_VER_REV1
-espefuse.py --port=socket://localhost:5555 burn_efuse CHIP_VER_REV2
+espefuse.py --before no_reset --port=socket://localhost:5555 burn_efuse CHIP_VER_REV1
+espefuse.py --before no_reset --port=socket://localhost:5555 burn_efuse CHIP_VER_REV2
 ```
 
 ## Disabling the watchdogs
@@ -230,13 +232,14 @@ The RTC watchdog timer is not emulated yet, so it doesn't need to be disabled.
     ```
 
     The final line redirects the emulated UART to TCP port 5555 (QEMU acts as a server).
-
-    Type q and press Enter at any time to quit.
+    >Please keep QEMU running until you have finished using it. Use a separate terminal to run the `esptool.py` and `espefuse.py` tools with the following commands. 
+    
+    Once you finish, type `q` and press Enter at any time to quit.
 
 1. Run esptool.py:
 
     ```
-    esptool.py -p socket://localhost:5555 flash_id
+    esptool.py --before no_reset -p socket://localhost:5555 flash_id
     ```
 
     Flashing with `idf.py` also works:
@@ -249,7 +252,7 @@ The RTC watchdog timer is not emulated yet, so it doesn't need to be disabled.
 1. Or, run espefuse.py:
 
     ```
-    espefuse.py --port socket://localhost:5555 --do-not-confirm burn_custom_mac 00:11:22:33:44:55
+    espefuse.py --before no_reset --port socket://localhost:5555 --do-not-confirm burn_custom_mac 00:11:22:33:44:55
     ```
 
 Note: `esptool` can **not** reset the emulated chip using the RTS signal, because the state of RTS is not transmitted over TCP to QEMU. To reset the emulated chip, run `system_reset` command in QEMU console (started at step 1).


### PR DESCRIPTION
**What was changed**
1. Added `--before no_reset` flag in running `esp_efuse.py` and `esp_tool.py`. Without the flag, the following error occurs:
```bash
espefuse.py v4.7.dev3
Connecting...
Device PID identification is only supported on COM and /dev/ serial ports.

Traceback (most recent call last):
  File "/opt/esp/python_env/idf5.1_py3.8_env/bin/espefuse.py", line 37, in <module>
    espefuse._main()
  File "/opt/esp/python_env/idf5.1_py3.8_env/lib/python3.8/site-packages/espefuse/__init__.py", line 295, in _main
    main()
  File "/opt/esp/python_env/idf5.1_py3.8_env/lib/python3.8/site-packages/espefuse/__init__.py", line 224, in main
    esp = get_esp(
  File "/opt/esp/python_env/idf5.1_py3.8_env/lib/python3.8/site-packages/espefuse/__init__.py", line 82, in get_esp
    esp = esptool.cmds.detect_chip(port, baud, connect_mode)
  File "/opt/esp/python_env/idf5.1_py3.8_env/lib/python3.8/site-packages/esptool/cmds.py", line 97, in detect_chip
    detect_port.connect(connect_mode, connect_attempts, detecting=True)
  File "/opt/esp/python_env/idf5.1_py3.8_env/lib/python3.8/site-packages/esptool/loader.py", line 676, in connect
    last_error = self._connect_attempt(reset_strategy, mode)
  File "/opt/esp/python_env/idf5.1_py3.8_env/lib/python3.8/site-packages/esptool/loader.py", line 561, in _connect_attempt
    reset_strategy()  # Reset the chip to bootloader (download mode)
  File "/opt/esp/python_env/idf5.1_py3.8_env/lib/python3.8/site-packages/esptool/reset.py", line 83, in __call__
    self._setDTRandRTS(False, False)
  File "/opt/esp/python_env/idf5.1_py3.8_env/lib/python3.8/site-packages/esptool/reset.py", line 48, in _setDTRandRTS
    "I", fcntl.ioctl(self.port.fileno(), TIOCMGET, struct.pack("I", 0))
OSError: [Errno 25] Inappropriate ioctl for device
```
2. Elaborate a bit more on unclear instructions.